### PR TITLE
thread: Give imap formatter correct type

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -41,7 +41,7 @@ func (cmd *ThreadCommand) Command() *imap.Command {
 	return &imap.Command{
 		Name: "THREAD",
 		Arguments: []interface{}{
-			cmd.Algorithm,
+			formatThreadAlgorithm(cmd.Algorithm),
 			cmd.Charset,
 			cmd.SearchCriteria.Format(),
 		},

--- a/sortthread.go
+++ b/sortthread.go
@@ -3,6 +3,10 @@
 // SORT and THREAD are defined in RFC 5256.
 package sortthread
 
+import (
+	"github.com/emersion/go-imap"
+)
+
 const SortCapability = "SORT"
 
 var ThreadCapabilities = []string{"THREAD=ORDEREDSUBJECT", "THREAD=REF", "THREAD=REFERENCES"}
@@ -14,6 +18,10 @@ const (
 	OrderedSubject ThreadAlgorithm = "ORDEREDSUBJECT"
 	References                     = "REFERENCES"
 )
+
+func formatThreadAlgorithm(algorithm ThreadAlgorithm) imap.RawString {
+	return imap.RawString(algorithm)
+}
 
 // SortField is a field that can be used to sort messages.
 type SortField string


### PR DESCRIPTION
Convert ThreadAlgorithm type to a string before passing it to the imap
formatter.