### PR TITLE
thread: Enable ALL search criteria

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -38,12 +38,22 @@ type ThreadCommand struct {
 }
 
 func (cmd *ThreadCommand) Command() *imap.Command {
+	args := []interface{}{
+		formatThreadAlgorithm(cmd.Algorithm),
+		cmd.Charset,
+	}
+
+	// Verify if SearchCriteria is empty to use "ALL" as criteria
+	isSearchCriteriaEmpty := cmd.SearchCriteria == nil || len(cmd.SearchCriteria.Format()) == 0
+
+	if isSearchCriteriaEmpty {
+		args = append(args, imap.RawString("ALL"))
+	} else {
+		args = append(args, cmd.SearchCriteria.Format())
+	}
+
 	return &imap.Command{
-		Name: "THREAD",
-		Arguments: []interface{}{
-			formatThreadAlgorithm(cmd.Algorithm),
-			cmd.Charset,
-			cmd.SearchCriteria.Format(),
-		},
+		Name:      "THREAD",
+		Arguments: args,
 	}
 }

--- a/commands.go
+++ b/commands.go
@@ -43,13 +43,21 @@ func (cmd *ThreadCommand) Command() *imap.Command {
 		cmd.Charset,
 	}
 
-	// Verify if SearchCriteria is empty to use "ALL" as criteria
-	isSearchCriteriaEmpty := cmd.SearchCriteria == nil || len(cmd.SearchCriteria.Format()) == 0
+	addAllSearchCriteria := true
 
-	if isSearchCriteriaEmpty {
+	// Verify if SearchCriteria is empty to use "ALL" as criteria
+	if cmd.SearchCriteria != nil {
+		searchFormat := cmd.SearchCriteria.Format()
+
+		if len(searchFormat) > 0 {
+			addAllSearchCriteria = false
+
+			args = append(args, searchFormat)
+		}
+	}
+
+	if addAllSearchCriteria {
 		args = append(args, imap.RawString("ALL"))
-	} else {
-		args = append(args, cmd.SearchCriteria.Format())
 	}
 
 	return &imap.Command{


### PR DESCRIPTION
I'm creating this pull request in order to fix this: https://github.com/emersion/go-imap-sortthread/issues/5.

It enables to execute the THREAD command with a `nil` or empty `imap.SearchCriteria` to perform the command with the search criteria `ALL`.