### PR TITLE
Fix string formatting for sort criteria - fixes #13

### DIFF
--- a/sortthread.go
+++ b/sortthread.go
@@ -50,9 +50,9 @@ func formatSortCriteria(criteria []SortCriterion) interface{} {
 	fields := make([]interface{}, 0, len(criteria))
 	for _, c := range criteria {
 		if c.Reverse {
-			fields = append(fields, "REVERSE")
+			fields = append(fields, imap.RawString("REVERSE"))
 		}
-		fields = append(fields, string(c.Field))
+		fields = append(fields, imap.RawString(c.Field))
 	}
 	return fields
 }


### PR DESCRIPTION
As suggested by @foxcpp, the strings in the command have to be `imap.RawString`. This fixes the problem for me in aerc.

Thanks @foxcpp!